### PR TITLE
fix/unfollow: request path

### DIFF
--- a/src/components/FollowedArtistList/FollowedArtistList.tsx
+++ b/src/components/FollowedArtistList/FollowedArtistList.tsx
@@ -37,7 +37,7 @@ const FollowedArtistList: React.FunctionComponent<ListProps> = ({ i18n }) => {
 
   function unfollowArtist(artistID: number) {
     setArtistLoading(artistID);
-    fetch(`${Endpoints.UnfollowArtist}?${artistID}`, {
+    fetch(`${Endpoints.UnfollowArtist}/${artistID}`, {
       method: 'DELETE',
       credentials: 'include',
     })


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the request path for the unfollow artist functionality by changing the artist ID from a query parameter to a path parameter.

Bug Fixes:
- Correct the request path for unfollowing an artist by changing the query parameter to a path parameter.

<!-- Generated by sourcery-ai[bot]: end summary -->