### PR TITLE
fix: recommended artists pagination 1 based

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,2 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx lint-staged
 yarn test --bail

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "lint": "next lint --fix",
     "test": "jest",
     "prettier": "prettier \"**/*\" --write",
-    "all": "yarn prettier && yarn lint && yarn test -u",
-    "prepare": "husky install"
+    "all": "yarn prettier && yarn lint && yarn test -u"
   },
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",

--- a/src/components/Recommendations/Recommendations.tsx
+++ b/src/components/Recommendations/Recommendations.tsx
@@ -12,7 +12,7 @@ type RecommendationsI18n = {
 
 const Recommendations = ({ i18n }: { i18n: RecommendationsI18n }) => {
   const [artistLoading, setArtistLoading] = React.useState<number>(0);
-  const url = `${Endpoints.Recommended}?page=0&size=10`;
+  const url = `${Endpoints.Recommended}?page=1&size=10`;
 
   const { rows: recommendedArtists } = resources.fetch(url) as components['schemas']['FollowedArtistsResponse'];
 

--- a/src/utils/Resources.test.ts
+++ b/src/utils/Resources.test.ts
@@ -3,12 +3,15 @@ import resources from './Resources';
 import Endpoints from '../types/endpoints';
 import { initServer } from './test-utils';
 
-xdescribe('Resources', () => {
+describe('Resources', () => {
   const server = initServer();
 
-  it('fetches resource', async () => {
+  it('throws a promise that Suspense can use', () => {
     server.use(mswRecommendedArtists.success());
-    const fetchedResources = resources.fetch(`${Endpoints.Recommended}?page=1&size=10`);
-    await expect(fetchedResources).resolves.toBe(1);
+    try {
+      resources.fetch(`${Endpoints.Recommended}?page=1&size=10`);
+    } catch (e) {
+      expect(e).toBeInstanceOf(Promise);
+    }
   });
 });

--- a/src/utils/Resources.test.ts
+++ b/src/utils/Resources.test.ts
@@ -8,7 +8,7 @@ xdescribe('Resources', () => {
 
   it('fetches resource', async () => {
     server.use(mswRecommendedArtists.success());
-    const fetchedResources = resources.fetch(`${Endpoints.Recommended}?page=0&size=10`);
+    const fetchedResources = resources.fetch(`${Endpoints.Recommended}?page=1&size=10`);
     await expect(fetchedResources).resolves.toBe(1);
   });
 });


### PR DESCRIPTION
## Summary by Sourcery

Fix the pagination for recommended artists to start from page 1 instead of page 0 and update the corresponding test to align with this change.

Bug Fixes:
- Fix pagination for recommended artists to be 1-based instead of 0-based.

Tests:
- Update test to reflect the change in pagination from 0-based to 1-based for recommended artists.