### PR TITLE
feat/clsx: integrate cslx/lite

### DIFF
--- a/__tests__/components/ArtistsList/components/List/__snapshots__/List.test.tsx.snap
+++ b/__tests__/components/ArtistsList/components/List/__snapshots__/List.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`List matches snapshot 1`] = `
       </a>
     </div>
     <button
-      class="btn flex "
+      class="btn flex btn-small lg:ml-8 my-2"
       type="button"
     >
       Follow
@@ -105,7 +105,7 @@ exports[`List matches snapshot 1`] = `
       </a>
     </div>
     <button
-      class="btn flex "
+      class="btn flex btn-small lg:ml-8 my-2 border-gh-dark!"
       type="button"
     >
       Follow

--- a/__tests__/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/__tests__/components/Button/__snapshots__/Button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Button matches snapshot 1`] = `
 <div>
   <button
-    class="btn flex "
+    class="btn flex"
     type="button"
   >
     <span

--- a/__tests__/components/ButtonFollowArtist/__snapshots__/ButtonFollowArtist.test.tsx.snap
+++ b/__tests__/components/ButtonFollowArtist/__snapshots__/ButtonFollowArtist.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ButtonFollowArtist matches snapshot 1`] = `
 <div>
   <button
-    class="btn flex "
+    class="btn flex"
     type="button"
   >
     Follow

--- a/__tests__/components/FollowedArtistList/__snapshots__/FollowedArtistList.test.tsx.snap
+++ b/__tests__/components/FollowedArtistList/__snapshots__/FollowedArtistList.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`FollowedArtistList matches snapshot 1`] = `
           </a>
         </div>
         <button
-          class="btn flex "
+          class="btn flex btn-small lg:ml-8 my-2"
           type="button"
         >
           Unfollow
@@ -132,7 +132,7 @@ exports[`FollowedArtistList matches snapshot 1`] = `
           </a>
         </div>
         <button
-          class="btn flex "
+          class="btn flex btn-small lg:ml-8 my-2 border-gh-dark!"
           type="button"
         >
           Unfollow

--- a/__tests__/components/Recommendations/__snapshots__/Recommendations.test.tsx.snap
+++ b/__tests__/components/Recommendations/__snapshots__/Recommendations.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`Recommendations matches snapshot 1`] = `
           </a>
         </div>
         <button
-          class="btn flex "
+          class="btn flex btn-small lg:ml-8 my-2"
           type="button"
         >
           Follow
@@ -116,7 +116,7 @@ exports[`Recommendations matches snapshot 1`] = `
           </a>
         </div>
         <button
-          class="btn flex "
+          class="btn flex btn-small lg:ml-8 my-2 border-gh-dark!"
           type="button"
         >
           Follow

--- a/__tests__/components/Search/__snapshots__/Search.test.tsx.snap
+++ b/__tests__/components/Search/__snapshots__/Search.test.tsx.snap
@@ -96,7 +96,7 @@ exports[`Search should handle the search action of the user 1`] = `
             </a>
           </div>
           <button
-            class="btn flex "
+            class="btn flex btn-small lg:ml-8 my-2"
             type="button"
           >
             Follow
@@ -137,7 +137,7 @@ exports[`Search should handle the search action of the user 1`] = `
             </a>
           </div>
           <button
-            class="btn flex "
+            class="btn flex btn-small lg:ml-8 my-2 border-gh-dark!"
             type="button"
           >
             Follow

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@auth0/nextjs-auth0": "^4.4.2",
+    "clsx": "^2.1.1",
     "next": "^15.3.4",
     "next-pwa": "^5.6.0",
     "react": "19.1.0",

--- a/src/components/ArtistsList/ArtistsList.tsx
+++ b/src/components/ArtistsList/ArtistsList.tsx
@@ -17,7 +17,7 @@ export type ArtistsListProp = {
 };
 
 const ArtistsList = ({ i18n, artistsList, artistLoading, buttonAction }: ArtistsListProp) => {
-  if (!i18n || !i18n.noArtists || !buttonAction) {
+  if (!i18n?.noArtists || !buttonAction) {
     return null;
   }
   return (

--- a/src/components/ArtistsList/components/List/List.tsx
+++ b/src/components/ArtistsList/components/List/List.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx/lite'; // Size (gzip): 140 bytes, CAUTION: Accepts ONLY string arguments!
 import React from 'react';
 
 import ButtonFollowArtist from '@/components/ButtonFollowArtist/ButtonFollowArtist';
@@ -5,7 +6,6 @@ import LastFm from '@/components/Icons/lastfm';
 import Spotify from '@/components/Icons/spotify';
 
 import { ArtistsListProp } from '../../ArtistsList';
-
 const ICON_SIZE = 30;
 
 const List = ({ artistsList, artistLoading, buttonAction }: ArtistsListProp) => {
@@ -35,7 +35,7 @@ const List = ({ artistsList, artistLoading, buttonAction }: ArtistsListProp) => 
           </div>
           <ButtonFollowArtist
             artist={artist}
-            className={`btn-small lg:ml-8 my-2 ${index % 2 ? 'border-gh-dark!' : ''}`}
+            className={clsx('btn-small lg:ml-8 my-2', index % 2 && 'border-gh-dark!')}
             disabled={!!artistLoading && artist.id === artistLoading}
             loading={!!artistLoading && artist.id === artistLoading}
             buttonAction={buttonAction}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,5 @@
 'use client';
+import clsx from 'clsx/lite';
 import React, { useCallback } from 'react';
 
 import followArtist from '@/utils/followArtist';
@@ -28,12 +29,7 @@ const Button: React.FunctionComponent<ButtonProps> = ({
   }
 
   return (
-    <button
-      className={`btn flex ${className ? className : ''}`}
-      onClick={handleClickCallback}
-      disabled={disabled}
-      type={type}
-    >
+    <button className={clsx('btn flex', className)} onClick={handleClickCallback} disabled={disabled} type={type}>
       {loading && (
         <span className="flex justify-center items-center -ml-1 mr-3 h-5 w-5">
           <Spin width={20} />

--- a/src/components/ButtonFollowArtist/ButtonFollowArtist.tsx
+++ b/src/components/ButtonFollowArtist/ButtonFollowArtist.tsx
@@ -13,6 +13,7 @@ const ButtonFollowArtist: React.FunctionComponent<ButtonFollowArtistType> = ({
   loading = false,
   artist,
   buttonAction,
+  className,
 }) => {
   const handleClickCallback = useCallback(async () => {
     if (!disabled) {
@@ -22,6 +23,7 @@ const ButtonFollowArtist: React.FunctionComponent<ButtonFollowArtistType> = ({
 
   return (
     <Button
+      className={className}
       handleClick={handleClickCallback}
       disabled={disabled}
       loading={loading}

--- a/src/components/Recommendations/Recommendations.tsx
+++ b/src/components/Recommendations/Recommendations.tsx
@@ -13,7 +13,7 @@ const Recommendations = async () => {
 
   return (
     <div className="flex flex-col lg:justify-center items-center mb-2 w-full">
-      <h3 className={'h3'}>{recommendationsI18n.title}</h3>
+      <h3 className="h3">{recommendationsI18n.title}</h3>
 
       <Suspense fallback={<Loading />}>
         <ArtistsList

--- a/src/components/Scrape/components/ScrapeButton.tsx
+++ b/src/components/Scrape/components/ScrapeButton.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx/lite';
 import React from 'react';
 
 import { Paths } from '@/types/endpoints';
@@ -29,7 +30,7 @@ const ScrapeButton = ({
   return (
     <div className="flex justify-center items-center w-full">
       <Button
-        className={`flex justify-between py-2 px-3 w-full md:w-48${connected ? ' rr-text-confirm!' : ''}`}
+        className={clsx('flex justify-between py-2 px-3 w-full md:w-48', connected && 'rr-text-confirm!')}
         i18n={buttonText}
         handleClick={() => handleScrape(musicService)}
         disabled={connected}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3234,6 +3234,11 @@ cliui@^8.0.1:
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
+clsx@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"


### PR DESCRIPTION
## Summary by Sourcery

Streamline className handling across components by integrating `clsx` for conditional styling, add support for forwarding custom `className` in `ButtonFollowArtist`, refine an i18n null-check, update TypeScript resolution settings, and refresh snapshots.

Enhancements:
- Replace manual template literal class concatenations with `clsx` in multiple components
- Introduce a `className` prop to `ButtonFollowArtist` for style forwarding
- Refine `ArtistsList` i18n presence check using optional chaining
- Update TypeScript configuration to use `moduleResolution: "bundler"`

Build:
- Add `clsx` as a project dependency

Tests:
- Refresh Jest snapshots to reflect updated className implementations