### PR TITLE
feat/fonts: add Inter font

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -34,7 +34,7 @@ const config: Config = {
     'src/**/*.{js,jsx,ts,tsx}',
     '!**/*.d.ts',
     '!src/types/schema.ts',
-    '!src/styles/schema.ts',
+    '!src/styles/*',
     '!**/*.{types,data}.ts',
   ],
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@ import '../styles/globals.css';
 
 import React from 'react';
 
+import { interFonts } from '@/styles/fonts';
+
 import Footer from '../components/Footer/Footer';
 import Header from '../components/Header/Header';
 import ThemeProvider from '../contexts/Theme/ThemeProvider';
@@ -9,7 +11,7 @@ import ThemeProvider from '../contexts/Theme/ThemeProvider';
 export default async function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en">
-      <body className="bg-white dark:bg-gh-dark">
+      <body className={`${interFonts.className} antialiased bg-white dark:bg-gh-dark`}>
         <div className="container max-auto">
           <div className="sm:border-x-2 rr-border flex flex-col h-screen">
             <Header />

--- a/src/styles/fonts.ts
+++ b/src/styles/fonts.ts
@@ -1,0 +1,3 @@
+import { Inter } from 'next/font/google';
+
+export const interFonts = Inter({ subsets: ['latin'] });


### PR DESCRIPTION
## Summary by Sourcery

Integrate the Inter Google font into the app and update Jest configuration accordingly

New Features:
- Add Inter font via next/font/google in a new styles/fonts.ts module

Enhancements:
- Include the Inter font’s className and `antialiased` utility on the root `<body>`

Tests:
- Expand Jest ignore patterns to exclude the entire styles directory instead of just schema.ts