### PR TITLE
feat/suspend: stream recommendations

### DIFF
--- a/__tests__/app/api/artist/search/route.test.ts
+++ b/__tests__/app/api/artist/search/route.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment node
  */
 import { GET } from '@/app/api/artist/search/route';
+
 import { readableStreamToString } from '../../../../testUtils/testUtils';
 
 jest.mock('@/lib/auth0', () => ({}));

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -34,6 +34,7 @@ const config: Config = {
     'src/**/*.{js,jsx,ts,tsx}',
     '!**/*.d.ts',
     '!src/types/schema.ts',
+    '!src/lib/auth0.ts',
     '!src/styles/*',
     '!**/*.{types,data}.ts',
   ],

--- a/src/app/api/artists/recommended/route.ts
+++ b/src/app/api/artists/recommended/route.ts
@@ -3,5 +3,6 @@ import { NextResponse } from 'next/server';
 import recommended from '@/mocks/fixtures/responses/recommended.json';
 
 export async function GET(): Promise<NextResponse> {
+  await new Promise(resolve => setTimeout(resolve, 3000));
   return NextResponse.json(recommended);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import '../styles/globals.css';
+import '@/styles/globals.css';
 
 import React from 'react';
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from 'next';
-import React from 'react';
+import React, { Suspense } from 'react';
 
+import RecommendationsSkeleton from '@/components/Recommendations/RecommendationsSkeleton/RecommendationsSkeleton';
 import { loginI18n, metaI18n, searchI18n } from '@/i18n';
 import { auth0 } from '@/lib/auth0';
 
@@ -32,7 +33,9 @@ export default async function Page() {
       {session?.user?.email && <Scrapers userEmail={session.user.email} />}
       <div className="flex flex-auto flex-col h24">
         <FollowedArtistList />
-        <Recommendations />
+        <Suspense fallback={<RecommendationsSkeleton />}>
+          <Recommendations />
+        </Suspense>
       </div>
     </ArtistsListProvider>
   );

--- a/src/components/Recommendations/Recommendations.tsx
+++ b/src/components/Recommendations/Recommendations.tsx
@@ -1,6 +1,5 @@
-import React, { Suspense } from 'react';
+import React from 'react';
 
-import Loading from '@/components/Loading/Loading';
 import { recommendationsI18n } from '@/i18n';
 import { Paths } from '@/types/endpoints';
 
@@ -15,13 +14,11 @@ const Recommendations = async () => {
     <div className="flex flex-col lg:justify-center items-center mb-2 w-full">
       <h3 className="h3">{recommendationsI18n.title}</h3>
 
-      <Suspense fallback={<Loading />}>
-        <ArtistsList
-          i18n={recommendationsI18n.artistList}
-          artistsList={recommendedArtists?.rows ?? []}
-          buttonAction={ButtonAction.Follow}
-        />
-      </Suspense>
+      <ArtistsList
+        i18n={recommendationsI18n.artistList}
+        artistsList={recommendedArtists?.rows ?? []}
+        buttonAction={ButtonAction.Follow}
+      />
     </div>
   );
 };

--- a/src/components/Recommendations/RecommendationsSkeleton/RecommendationsSkeleton.tsx
+++ b/src/components/Recommendations/RecommendationsSkeleton/RecommendationsSkeleton.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import Loading from '@/components/Loading/Loading';
+import { recommendationsI18n } from '@/i18n';
+
+export default function RecommendationsSkeleton() {
+  return (
+    <div className="flex flex-col lg:justify-center items-center mb-2 w-full">
+      <h3 className="h3">{recommendationsI18n.title}</h3>
+
+      <Loading />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary by Sourcery

Relocate the Suspense boundary for the recommendations stream to the page component, introduce a skeleton fallback UI, simulate network delay in the recommendations API, and update Jest configuration accordingly.

New Features:
- Add RecommendationsSkeleton component as a loading fallback for recommendations

Enhancements:
- Move Suspense boundary from the Recommendations component to its parent page
- Introduce a 3-second artificial delay in the recommended artists API route to simulate network latency

Tests:
- Update Jest config to exclude the auth0 utility from test patterns