### PR TITLE
fix/login: redirect to /profile

### DIFF
--- a/src/lib/auth0.ts
+++ b/src/lib/auth0.ts
@@ -1,8 +1,11 @@
 import { Auth0Client } from '@auth0/nextjs-auth0/server';
 
+import { NavigationPaths } from '@/types/endpoints';
+
 export const auth0 = new Auth0Client({
   authorizationParameters: {
     scope: process.env.API_SCOPE,
     audience: process.env.API_AUDIENCE,
   },
+  signInReturnToPath: NavigationPaths.Profile,
 });


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Redirect users to /profile by setting signInReturnToPath to NavigationPaths.Profile in Auth0 configuration