### PR TITLE
feat/refreshToken: enable

### DIFF
--- a/src/app/api/me/enable-services/route.ts
+++ b/src/app/api/me/enable-services/route.ts
@@ -1,9 +1,8 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
-import { auth0 } from '@/lib/auth0';
 import { API_Paths } from '@/types/endpoints';
 
-export async function POST(): Promise<
+export async function POST(req: NextRequest): Promise<
   NextResponse<
     | { status: number }
     | {
@@ -12,11 +11,11 @@ export async function POST(): Promise<
   >
 > {
   try {
-    const accessToken = await auth0.getAccessToken();
+    const authorization = req.headers.get('Authorization');
 
     const response = await fetch(`${process.env.API_BASE_URL}/${API_Paths.EnableSrapeServices}`, {
       headers: {
-        authorization: `Bearer ${accessToken.token}`,
+        ...(authorization && { authorization }),
         'content-type': 'application/json',
         'Referrer-Policy': 'strict-origin-when-cross-origin',
       },

--- a/src/lib/getRecommendations.ts
+++ b/src/lib/getRecommendations.ts
@@ -5,7 +5,7 @@ import { API_Paths } from '@/types/endpoints';
 
 export async function getRecommendations() {
   try {
-    const accessToken = await auth0.getAccessToken();
+    const accessToken = await auth0.getAccessToken({ refresh: true });
 
     // const response = await fetch(`${process.env.API_BASE_URL}/${API_Paths.Recommended}?${req.nextUrl.searchParams}`, {
     const response = await fetch(`${process.env.API_BASE_URL}/${API_Paths.Recommended}?page=1&size=10`, {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -14,27 +14,26 @@ export async function middleware(request: NextRequest) {
 
   // user is not authenticated in protected pages, redirect to login page
   if (!session && request.nextUrl.pathname !== '/') {
-    return NextResponse.redirect(new URL('/', request.nextUrl.origin));
-  }
-
-  if (!isTokenExpired(session)) {
-    await auth0.updateSession(request, authRes, {
-      ...session,
-      user: {
-        ...session!.user,
-        updatedAt: Date.now(),
-      },
-    } as SessionData);
+    const res = NextResponse.redirect(new URL('/', request.nextUrl.origin));
+    res.cookies.delete('__session');
+    return res;
   }
 
   // forward access token to API routes
   if (session && request.nextUrl.pathname.includes('api')) {
-    const accessToken = await auth0.getAccessToken(request, authRes);
+    const accessToken = await getValidAccessToken();
     authRes.headers.set('Authorization', `Bearer ${accessToken.token}`);
   }
 
   // the headers from the auth middleware should always be returned
   return authRes;
+
+  async function getValidAccessToken(): Promise<{ token: string; expiresAt: number; scope?: string }> {
+    if (isTokenExpired(session)) {
+      return await auth0.getAccessToken(request, authRes, { refresh: true });
+    }
+    return await auth0.getAccessToken(request, authRes);
+  }
 }
 
 function isTokenExpired(session: SessionData | null): boolean {
@@ -49,6 +48,6 @@ export const config = {
      * - _next/image (image optimization files)
      * - favicon.ico, sitemap.xml, robots.txt (metadata files)
      */
-    '/((?!_next/static|_next/image|sw.js|workbox|app_icons|favicon.ico|favicon.svg|sitemap.xml|robots.txt|manifest.json|noflash.js).*)',
+    '/((?!_next/static|_next/image|sw.js|workbox|app_icons|favicon.ico|favicon.svg|apple-icon.png|sitemap.xml|robots.txt|manifest.json|noflash.js).*)',
   ],
 };


### PR DESCRIPTION
## Summary by Sourcery

Enable token refresh across middleware and client API calls, streamline session handling by removing outdated expiration logic and session updates, and adjust middleware to clear session cookies on redirect.

Enhancements:
- Always request refreshed access tokens in middleware and getRecommendations
- Remove custom token expiration check and session update logic from middleware
- Clear __session cookie when redirecting unauthorized users to the login page
- Forward incoming Authorization header in the enable-services API route instead of fetching a new token
- Include apple-icon.png in the middleware static file matcher