### PR TITLE
fix/middleware: exlude public path from auth

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -48,6 +48,6 @@ export const config = {
      * - _next/image (image optimization files)
      * - favicon.ico, sitemap.xml, robots.txt (metadata files)
      */
-    '/((?!_next/static|_next/image|sw.js|workbox|app_icons|favicon.ico|favicon.svg|apple-icon.png|sitemap.xml|robots.txt|manifest.json|noflash.js).*)',
+    '/((?!_next/static|_next/image|sw.js|workbox|app_icons|api/stats|favicon.ico|favicon.svg|apple-icon.png|sitemap.xml|robots.txt|manifest.json|noflash.js).*)',
   ],
 };


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Exclude the 'api/stats' endpoint from authentication in middleware.