### PR TITLE
feat/tabs: render lists on tabs

### DIFF
--- a/__tests__/components/FollowedArtistList/__snapshots__/FollowedArtistList.test.tsx.snap
+++ b/__tests__/components/FollowedArtistList/__snapshots__/FollowedArtistList.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`FollowedArtistList matches snapshot 1`] = `
 <div>
   <div
-    class="flex flex-col flex-1 items-center mb-2 border-b-2 rr-border w-full"
+    class="flex flex-col flex-1 items-center mb-2 border-b-2 rr-border w-full h-full"
   >
     <h3
       class="h3"
@@ -27,7 +27,7 @@ exports[`FollowedArtistList matches snapshot 1`] = `
       </form>
     </div>
     <div
-      class="overflow-auto w-full flex-auto h-64"
+      class="overflow-auto w-full h-150"
     >
       <div
         class="flex justify-between items-center dark:even:bg-gh-darkly even:bg-gray-100"

--- a/__tests__/components/Tabs/Tabs.test.tsx
+++ b/__tests__/components/Tabs/Tabs.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render } from '@testing-library/react';
+import React from 'react';
+
+import Tabs from '@/components/Tabs/Tabs';
+
+const tabs = [
+  {
+    label: 'Tab 1',
+    content: <div>Content 1</div>,
+  },
+  {
+    label: 'Tab 2',
+    content: <div>Content 2</div>,
+  },
+];
+
+describe('Tabs', () => {
+  it('renders tabs with the first tab active', () => {
+    const { getByText } = render(<Tabs tabs={tabs} />);
+
+    expect(getByText('Tab 1')).toHaveClass('border-b-2 border-blue-500 text-blue-500');
+    expect(getByText('Content 1')).toBeInTheDocument();
+  });
+
+  it('switches to the second tab on click', () => {
+    const { getByText } = render(<Tabs tabs={tabs} />);
+
+    fireEvent.click(getByText('Tab 2'));
+
+    expect(getByText('Tab 2')).toHaveClass('border-b-2 border-blue-500 text-blue-500');
+    expect(getByText('Content 2')).toBeInTheDocument();
+  });
+
+  it('matches snapshot', () => {
+    const { container } = render(<Tabs tabs={tabs} />);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/__tests__/components/Tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/__tests__/components/Tabs/__snapshots__/Tabs.test.tsx.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tabs matches snapshot 1`] = `
+<div>
+  <div>
+    <div
+      class="flex border-b border-gray-200 justify-center"
+    >
+      <button
+        class="py-2 px-4 text-sm font-medium text-center border-b-2 border-blue-500 text-blue-500"
+      >
+        Tab 1
+      </button>
+      <button
+        class="py-2 px-4 text-sm font-medium text-center text-gray-500 hover:text-gray-700"
+      >
+        Tab 2
+      </button>
+    </div>
+    <div
+      class="flex p-4 tab-content flex-grow"
+    >
+      <div>
+        Content 1
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,12 +24,12 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
     <html lang="en">
       <body className={`${interFonts.className} antialiased bg-white dark:bg-gh-dark`}>
         <ThemeProvider>
-          <div className="container max-auto">
+          <div className="container">
             <div className="sm:border-x-2 rr-border flex flex-col h-screen">
               <Header />
 
               <main className="rr-column flex-auto">
-                <div className="flex flex-col flex-auto w-full lg:w-9/12">{children}</div>
+                <div className="flex flex-col w-full lg:w-9/12">{children}</div>
               </main>
 
               <Footer />

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -4,21 +4,32 @@ import FollowedArtistList from '@/components/FollowedArtistList/FollowedArtistLi
 import Recommendations from '@/components/Recommendations/Recommendations';
 import RecommendationsSkeleton from '@/components/Recommendations/RecommendationsSkeleton/RecommendationsSkeleton';
 import Search from '@/components/Search/Search';
+import Tabs from '@/components/Tabs/Tabs';
 import ArtistsListProvider from '@/contexts/ArtistsList/ArtistsListProvider';
 import SearchProvider from '@/contexts/Search/SearchProvider';
 import { searchI18n } from '@/i18n';
 
 export default async function Page() {
+  const tabs = [
+    {
+      label: 'Followed Artists',
+      content: <FollowedArtistList />,
+    },
+    {
+      label: 'Recommendations',
+      content: (
+        <Suspense fallback={<RecommendationsSkeleton />}>
+          <Recommendations />
+        </Suspense>
+      ),
+    },
+  ];
+
   return (
     <ArtistsListProvider>
       <SearchProvider>
         <Search i18n={searchI18n} />
-        <div className="flex flex-auto flex-col h24">
-          <FollowedArtistList />
-          <Suspense fallback={<RecommendationsSkeleton />}>
-            <Recommendations />
-          </Suspense>
-        </div>
+        <Tabs tabs={tabs} />
       </SearchProvider>
     </ArtistsListProvider>
   );

--- a/src/components/ArtistsList/ArtistsList.tsx
+++ b/src/components/ArtistsList/ArtistsList.tsx
@@ -20,7 +20,7 @@ const ArtistsList = ({ i18n, artistsList, buttonAction }: ArtistsListProp) => {
     return null;
   }
   return (
-    <div className="overflow-auto w-full flex-auto h-64">
+    <div className="overflow-auto w-full h-150">
       {!artistsList?.length ? (
         <p className="rr-text flex justify-center">{i18n.noArtists}</p>
       ) : (

--- a/src/components/FollowedArtistList/FollowedArtistList.tsx
+++ b/src/components/FollowedArtistList/FollowedArtistList.tsx
@@ -15,7 +15,7 @@ const FollowedArtistList: React.FunctionComponent = () => {
   const [filterInput, setFilterInput] = useState('');
 
   return (
-    <div className="flex flex-col flex-1 items-center mb-2 border-b-2 rr-border w-full">
+    <div className="flex flex-col flex-1 items-center mb-2 border-b-2 rr-border w-full h-full">
       <h3 className="h3">{followedArtistListI18n.title}</h3>
       <div className="flex justify-around items-center w-2/3">
         <FormInput handleAction={setFilterInput} i18n={followedArtistListI18n.formInput} />

--- a/src/components/Recommendations/Recommendations.tsx
+++ b/src/components/Recommendations/Recommendations.tsx
@@ -11,7 +11,7 @@ const Recommendations = async () => {
   const recommendedArtists = await data.json();
 
   return (
-    <div className="flex flex-col lg:justify-center items-center mb-2 w-full">
+    <div className="flex flex-col lg:justify-center items-center mb-2 w-full h-full">
       <h3 className="h3">{recommendationsI18n.title}</h3>
 
       <ArtistsList

--- a/src/components/Tabs/Tabs.css
+++ b/src/components/Tabs/Tabs.css
@@ -1,0 +1,12 @@
+.tab-content {
+  animation: fadeIn 0.5s;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import './Tabs.css';
+
+import clsx from 'clsx';
+import React, { useState } from 'react';
+
+interface Tab {
+  label: string;
+  content: React.ReactNode;
+}
+
+interface TabsProps {
+  tabs: Tab[];
+}
+
+const Tabs: React.FC<TabsProps> = ({ tabs }) => {
+  const [activeTab, setActiveTab] = useState(0);
+
+  return (
+    <div>
+      <div className="flex border-b border-gray-200 justify-center">
+        {tabs.map((tab, index) => (
+          <button
+            key={index}
+            className={clsx('py-2 px-4 text-sm font-medium text-center', {
+              'border-b-2 border-blue-500 text-blue-500': activeTab === index,
+              'text-gray-500 hover:text-gray-700': activeTab !== index,
+            })}
+            onClick={() => setActiveTab(index)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      <div className="flex p-4 tab-content flex-grow">{tabs[activeTab].content}</div>
+    </div>
+  );
+};
+
+export default Tabs;


### PR DESCRIPTION
## Summary by Sourcery

Add a Tabs component and integrate it into the profile page to toggle between Followed Artists and Recommendations, while refining layout and list styling for full-height display and adding CSS animations and tests for the new component.

New Features:
- Introduce a Tabs component with a tab bar and fade-in animation for content transitions
- Replace stacked lists in the profile page with the Tabs component to separate Followed Artists and Recommendations

Enhancements:
- Adjust global layout container classes by removing redundant flex-auto and max-auto modifiers
- Update list components to use full-height containers and refine overflow heights for consistent scrolling

Tests:
- Add unit tests and snapshots for the Tabs component to verify initial active tab and content switching