### PR TITLE
fix/footer: copywrite

### DIFF
--- a/__tests__/components/Footer/Footer.test.tsx
+++ b/__tests__/components/Footer/Footer.test.tsx
@@ -4,7 +4,7 @@ import Footer from '@/components/Footer/Footer';
 
 jest.mock('@/i18n', () => ({
   footerI18n: {
-    powered: 'Powered by',
+    copyright: '© Release Raccoon',
   },
 }));
 
@@ -16,9 +16,8 @@ describe('Footer', () => {
     expect(supportLink).toBeInTheDocument();
     expect(supportLink.closest('a')).toHaveAttribute('href', '/support');
 
-    const poweredByLink = getByText('Powered by');
-    expect(poweredByLink).toBeInTheDocument();
-    expect(poweredByLink.closest('a')).toHaveAttribute('href', 'https://github.com/jaivalis/release-raccoon');
+    const copyrightText = getByText(`© Release Raccoon ${new Date().getFullYear()}`);
+    expect(copyrightText).toBeInTheDocument();
   });
 
   it('matches snapshot', () => {

--- a/__tests__/components/Footer/__snapshots__/Footer.test.tsx.snap
+++ b/__tests__/components/Footer/__snapshots__/Footer.test.tsx.snap
@@ -6,38 +6,13 @@ exports[`Footer matches snapshot 1`] = `
     class="flex items-center justify-between flex-none h-16 px-4 border-t-2 rr-border"
   >
     <div />
-    <a
+    <p
       class="flex items-center rr-text"
-      href="https://github.com/jaivalis/release-raccoon"
-      rel="noopener noreferrer"
-      target="_blank"
     >
-      Powered by
-      <div
-        class="mx-2"
-      >
-        <svg
-          class="h-8 w-8 icon-colour"
-          fill="none"
-          height="24"
-          role="img"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="1.5"
-          viewBox="0 0 24 24"
-          width="24"
-        >
-          <path
-            d="M0 0h24v24H0z"
-            stroke="none"
-          />
-          <path
-            d="M9 19c-4.286 1.35-4.286-2.55-6-3m12 5v-3.5c0-1 .099-1.405-.5-2 2.791-.3 5.5-1.366 5.5-6.04a4.567 4.567 0 00-1.333-3.21 4.192 4.192 0 00-.08-3.227s-1.05-.3-3.476 1.267a12.334 12.334 0 00-6.222 0C6.462 2.723 5.413 3.023 5.413 3.023a4.192 4.192 0 00-.08 3.227A4.566 4.566 0 004 9.486c0 4.64 2.709 5.68 5.5 6.014-.591.589-.56 1.183-.5 2V21"
-          />
-        </svg>
-      </div>
-    </a>
+      © Release Raccoon
+       
+      2025
+    </p>
     <a
       class="rr-text mr-4"
       href="/support"

--- a/__tests__/i18n.test.ts
+++ b/__tests__/i18n.test.ts
@@ -89,8 +89,8 @@ describe('formInputI18n', () => {
 });
 
 describe('footerI18n', () => {
-  it('should have correct powered', () => {
-    expect(footerI18n.powered).toBe('Powered by');
+  it('should have correct copyright', () => {
+    expect(footerI18n.copyright).toBe('© Release Raccoon');
   });
 });
 

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -3,27 +3,17 @@ import React from 'react';
 
 import { footerI18n } from '@/i18n';
 
-import Github from '../Icons/github';
-
 const Footer: React.FunctionComponent = () => {
-  if (!footerI18n?.powered) {
+  if (!footerI18n?.copyright) {
     return null;
   }
 
   return (
     <footer className="flex items-center justify-between flex-none h-16 px-4 border-t-2 rr-border">
       <div />
-      <a
-        className="flex items-center rr-text"
-        href="https://github.com/jaivalis/release-raccoon"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        {footerI18n.powered}
-        <div className="mx-2">
-          <Github />
-        </div>
-      </a>
+      <p className="flex items-center rr-text">
+        {footerI18n.copyright} {new Date().getFullYear()}
+      </p>
       <Link href="/support" className="rr-text mr-4">
         Support
       </Link>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -88,7 +88,7 @@ export const formInputI18n = {
 };
 
 export const footerI18n = {
-  powered: 'Powered by',
+  copyright: '© Release Raccoon',
 };
 export const artistsListI18n = {
   noArtists: 'You do not track any artists yet',


### PR DESCRIPTION
## Summary by Sourcery

Refactor the Footer component to display a static copyright notice with the current year instead of an external "Powered by" link, update the i18n key accordingly, and adjust tests and snapshots to match.

Enhancements:
- Replace the footer’s external “Powered by” GitHub link with a static copyright notice including the current year
- Remove the GitHub icon import and related anchor element from the Footer component
- Rename the i18n footer key from powered to copyright and update its value

Tests:
- Update Footer component tests and snapshot to expect the new copyright text with the year and remove link assertions